### PR TITLE
correct folder existence checks for .local/bin and .local/share

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,12 +39,12 @@ fi
 echo ":: Downloading latest version of packages-installer..."
 git clone --quiet --depth 1 https://github.com/mylinuxforwork/packages-installer.git $HOME/.cache/packages-installer  > /dev/null
 
-# Create folders id not exists
-if [ ! -f "$HOME/.local/bin" ]; then
+# Create folders if not exists
+if [ ! -d "$HOME/.local/bin" ]; then
     mkdir -p "$HOME/.local/bin"
 fi
 
-if [ ! -f "$HOME/.local/share" ]; then
+if [ ! -d "$HOME/.local/share" ]; then
     mkdir -p "$HOME/.local/share"
 fi
 


### PR DESCRIPTION
- Replaced incorrect `-f` (file check) with `-d` (directory check) for .local/bin and .local/share.
- Fixed a typo in the comment ("id not exists" → "if not exists").

This ensures proper behavior and improves code clarity.

**Note**:
I understand the project is in beta, and I’ve been eagerly waiting for it. I thought these small fixes might be helpful at this stage. I wanted to contribute even without a formal contribution guide. Thank you for creating this project — I look forward to seeing how it develops